### PR TITLE
Exit with a non-zero status code

### DIFF
--- a/bin/publish.php
+++ b/bin/publish.php
@@ -53,4 +53,5 @@ try {
     $client->packages()->createArtifactPackage([$response['id']]);
 } catch (HttpTransportException $e) {
     echo sprintf("Error when calling %s, status code: %s, message: %s\n", $e->getRequestUri(), $e->getCode(), $e->getMessage());
+    exit(1);
 }


### PR DESCRIPTION
Exit with a non-zero status code if we did not receive a successful response. 